### PR TITLE
Bidi overspecified

### DIFF
--- a/src/__tests__/vectors/username-case-mapped.json
+++ b/src/__tests__/vectors/username-case-mapped.json
@@ -128,6 +128,10 @@
     "Output": "e1b9a1"
   },
   {
+    "Input": "21",
+    "Output": "21"
+  },
+  {
     "Input": "d090",
     "Output": "d0b0"
   },

--- a/src/baseclass.ts
+++ b/src/baseclass.ts
@@ -48,7 +48,7 @@ const enforceContextRule = (
   cs: ReadonlyArray<string>,
   i: number,
 ): void => {
-  const cp = cs[i].codePointAt(0)!;
+  const cp = codepoint(cs[i]);
   let fn;
   switch (cp) {
     case 0x200c:
@@ -101,11 +101,11 @@ const enforceContextRule = (
 };
 
 const contextZeroWidthNonJoiner: ContextFn = (cs, i, text) =>
-  isVirma(before(text, cs, i).codePointAt(0)!) ||
+  isVirma(codepoint(before(text, cs, i))) ||
   (nonJoinerValidBefore(cs, i) && nonJoinerValidAfter(cs, i));
 
 const contextZeroWidthJoiner: ContextFn = (cs, i, text) =>
-  isVirma(before(text, cs, i).codePointAt(0)!);
+  isVirma(codepoint(before(text, cs, i)));
 
 const contextMiddleDot: ContextFn = (cs, i, text) =>
   before(text, cs, i) === '\u006c' && after(text, cs, i) === '\u006c';
@@ -132,7 +132,7 @@ const nonJoinerValidBefore = (
   i: number,
 ): boolean => {
   for (let j = i - 1; j >= 0; --j) {
-    const t = getJoiningType(cs[j].codePointAt(0)!);
+    const t = getJoiningType(codepoint(cs[j]));
     switch (t) {
       case 'T':
         continue;
@@ -148,7 +148,7 @@ const nonJoinerValidBefore = (
 
 const nonJoinerValidAfter = (cs: ReadonlyArray<string>, i: number): boolean => {
   for (let j = i + 1; j < cs.length; ++j) {
-    const t = getJoiningType(cs[j].codePointAt(0)!);
+    const t = getJoiningType(codepoint(cs[j]));
     switch (t) {
       case 'T':
         continue;

--- a/src/bidi.ts
+++ b/src/bidi.ts
@@ -35,7 +35,7 @@ const hasRTL = (cs: ReadonlyArray<string>): boolean =>
 
 const validateLTR = (text: string, cs: ReadonlyArray<string>): void => {
   cs.forEach((c, i) => {
-    const bc = getBidiClass(c.codePointAt(0)!);
+    const bc = getBidiClass(codepoint(c));
     switch (bc) {
       case 'L':
       case 'EN':
@@ -51,7 +51,7 @@ const validateLTR = (text: string, cs: ReadonlyArray<string>): void => {
     }
   });
   for (let i = cs.length - 1; i >= 0; ++i) {
-    const bc = getBidiClass(cs[i].codePointAt(0)!);
+    const bc = getBidiClass(codepoint(cs[i]));
     switch (bc) {
       case 'NSM':
         continue;

--- a/src/bidi.ts
+++ b/src/bidi.ts
@@ -3,10 +3,10 @@ import {getBidiClass} from './prop';
 import {codepoint} from './util';
 
 export const validateBidiRule = (text: string): void => {
-  if (text.length === 0) {
-    throw new EmptyStringError(text);
-  }
   const cs = [...text];
+  if (!hasRTL(cs)) {
+    return;
+  }
   let validate = validateLTR;
   switch (getBidiClass(codepoint(cs[0]))) {
     case 'R':
@@ -20,6 +20,18 @@ export const validateBidiRule = (text: string): void => {
   }
   validate(text, cs);
 };
+
+const hasRTL = (cs: ReadonlyArray<string>): boolean =>
+  cs.some(c => {
+    switch (getBidiClass(codepoint(c))) {
+      case 'R':
+      case 'AL':
+      case 'AN':
+        return true;
+      default:
+        return false;
+    }
+  });
 
 const validateLTR = (text: string, cs: ReadonlyArray<string>): void => {
   cs.forEach((c, i) => {


### PR DESCRIPTION
This fixes the bidi rule being applied to cases where it should not.
Specifically, strings containing no RTL codepoints.